### PR TITLE
superUser can create appointment without employees

### DIFF
--- a/mcpressureapi/views/appointment_view.py
+++ b/mcpressureapi/views/appointment_view.py
@@ -116,7 +116,6 @@ class AppointmentView(ViewSet):
             if is_fields_missing:
                     return Response({"message": missing_fields}, status = status.HTTP_400_BAD_REQUEST)
 
-
             customer = Customer.objects.get(user=request.auth.user)
             service_type = ServiceType.objects.get(pk=request.data["service_type"])
             progress = Progress.objects.get(pk=request.data["progress"])


### PR DESCRIPTION
- [x] Admin/SuperUser or Employee can create an appointment with/without claiming

```py
employees = request.data.get("employee", None)

            customer = Customer.objects.get(pk=request.data["customer"])
            service_type = ServiceType.objects.get(pk=request.data["service_type"])
            progress = Progress.objects.get(pk=request.data["progress"])

            appointment = Appointments.objects.create(
                customer=customer,
                service_type=service_type,
                request_details=request.data["request_details"],
                request_date=request.data["request_date"],
                image=request.data["image"],
                progress = progress,
                scheduled = False,
                consultation= False,
                completed=False,
                confirm=False,
            )

            if employees is not None:
                for employee in employees:
                    employees_to_assign = Employee.objects.get(pk=employee)
                    employee_appointment = EmployeeAppointment()
                    employee_appointment.employee = employees_to_assign
                    employee_appointment.appointment = appointment
                    employee_appointment.save()
```