### PR TITLE
added custom delete method to remove specialties from employee

### DIFF
--- a/mcpressureapi/views/appointment_view.py
+++ b/mcpressureapi/views/appointment_view.py
@@ -31,28 +31,6 @@ class AppointmentView(ViewSet):
         # returns 200 status and message 
         return Response({'message':'Employees has left the appointment'}, status=status.HTTP_200_OK)
 
-    # def list(self, request):
-    #     """Handle GET requests to get all Appointments
-
-    #     Returns:
-    #         Response -- JSON serialized list of appointments
-    #     """
-
-    #     # user = User.objects.get(pk=request.auth.user_id)
-    #     try: 
-    #         log_user = Customer.objects.get(user=request.auth.user)
-
-    #         if log_user:
-    #             appointments = Appointments.objects.filter(customer_id = log_user)
-
-    #     except:
-    #         # user.is_staff
-    #         # get all appointments
-    #         appointments = Appointments.objects.all()
-            
-    #     serialized = AppointmentsSerializer(appointments, many=True)
-    #     return Response(serialized.data, status=status.HTTP_200_OK)
-
     def list(self, request):
         """Handle GET requests to get all Appointments
 

--- a/mcpressureapi/views/employee_view.py
+++ b/mcpressureapi/views/employee_view.py
@@ -24,6 +24,29 @@ class EmployeeView(ViewSet):
         serializer = EmployeeSerializer(employee)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+#* Remove specialty Employee Method
+# action decorator accepts delete request (methods=['delete]) and a detail route (detail=True)
+    @action(methods=['delete'], detail=True)
+    def remove_specialty(self, request, pk):
+        """DELETE request for a Admin to remove_specialty an from Employee details"""
+        #retrieves specialty primary keys to remove_specialty from request data
+        specialty_pks = request.data.get("specialty_pks")
+        #retrieves employee by primary key
+        employee = Employee.objects.get(pk=pk)
+        for specialty_pk in specialty_pks:
+            #retrieves specialty by primary key
+            skill = Specialty.objects.filter(pk=specialty_pk).first()
+            # check if specialty exists or not
+            if skill is None:
+                # returns a 404 status with a message if specialty does not exist
+                return Response({'message': f'Specialty {specialty_pk} does not exist'}, status=status.HTTP_404_NOT_FOUND)
+            #removes specialty from join table
+            EmployeeServiceTypeSpecialty.objects.filter(specialty=skill, employee=employee).delete()
+        # returns 200 status and message 
+        return Response({'message':'Specialty has been removed from Employee'}, status=status.HTTP_200_OK)
+
+
+
     def list(self, request):
         """Get request to get all Employees
 


### PR DESCRIPTION
Updates...
custom action added to Employee to delete Specialty(ies) from employee when needed.
```py
#* Remove specialty Employee Method
# action decorator accepts delete request (methods=['delete]) and a detail route (detail=True)
    @action(methods=['delete'], detail=True)
    def remove_specialty(self, request, pk):
        """DELETE request for a Admin to remove_specialty an from Employee details"""
        #retrieves specialty primary keys to remove_specialty from request data
        specialty_pks = request.data.get("specialty_pks")
        #retrieves employee by primary key
        employee = Employee.objects.get(pk=pk)
        for specialty_pk in specialty_pks:
            #retrieves specialty by primary key
            skill = Specialty.objects.filter(pk=specialty_pk).first()
            # check if specialty exists or not
            if skill is None:
                # returns a 404 status with a message if specialty does not exist
                return Response({'message': f'Specialty {specialty_pk} does not exist'}, status=status.HTTP_404_NOT_FOUND)
            #removes specialty from join table
            EmployeeServiceTypeSpecialty.objects.filter(specialty=skill, employee=employee).delete()
        # returns 200 status and message 
        return Response({'message':'Specialty has been removed from Employee'}, status=status.HTTP_200_OK)
```
