### PR TITLE
create and destroy method added to location_view.py

### DIFF
--- a/mcpressureapi/views/location_view.py
+++ b/mcpressureapi/views/location_view.py
@@ -36,6 +36,38 @@ class LocationView(ViewSet):
             serialized = LocationSerializer(location, context={'request': request})
             return Response(serialized.data, status=status.HTTP_200_OK)
 
+    
+    def create(self, request):
+        city_pk = request.data["city"]
+        try:
+            city_instance = City.objects.get(pk=city_pk)
+        except City.DoesNotExist:
+            # If the city doesn't exist, create a new City instance
+            city_instance = City.objects.create(pk=city_pk)
+
+        location = Location.objects.create(
+            street=request.data["street"],
+            city=city_instance
+        )
+        serialized = LocationSerializer(location, many=False)
+        return Response(serialized.data, status=status.HTTP_201_CREATED)
+
+    
+    def destroy(self, request, pk):
+        """Handle DELETE request for locations
+
+           Returns:
+            Response -- "message": "This location has been DELETED"} and status=status.HTTP_204_NO_CONTENT
+        """
+
+        try:
+            location = Location.objects.get(pk=pk)
+            location.delete()
+            return Response({"message": "This location has been DELETED"}, status=status.HTTP_204_NO_CONTENT)
+        except Location.DoesNotExist:
+            return Response({"message": "The location you specified does not exist"}, status = status.HTTP_404_NOT_FOUND)
+
+
 class CitySerializer(serializers.ModelSerializer):
     class Meta:
         model = City


### PR DESCRIPTION
```py
 def create(self, request):
        city_pk = request.data["city"]
        try:
            city_instance = City.objects.get(pk=city_pk)
        except City.DoesNotExist:
            # If the city doesn't exist, create a new City instance
            city_instance = City.objects.create(pk=city_pk)

        location = Location.objects.create(
            street=request.data["street"],
            city=city_instance
        )
        serialized = LocationSerializer(location, many=False)
        return Response(serialized.data, status=status.HTTP_201_CREATED)

    
    def destroy(self, request, pk):
        """Handle DELETE request for locations

           Returns:
            Response -- "message": "This location has been DELETED"} and status=status.HTTP_204_NO_CONTENT
        """

        try:
            location = Location.objects.get(pk=pk)
            location.delete()
            return Response({"message": "This location has been DELETED"}, status=status.HTTP_204_NO_CONTENT)
        except Location.DoesNotExist:
            return Response({"message": "The location you specified does not exist"}, status = status.HTTP_404_NOT_FOUND)
```